### PR TITLE
Reference the new data images

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/jbirddog/type-ahead-data:main AS data
+FROM ghcr.io/jbirddog/typeahead-data:main AS data
 
 FROM rust:1-slim-bullseye AS build
 

--- a/lambda.Dockerfile
+++ b/lambda.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/jbirddog/type-ahead-data:main AS data
+FROM ghcr.io/jbirddog/typeahead-data:main AS data
     
 FROM calavera/cargo-lambda AS base
 

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/jbirddog/type-ahead-data:main AS data
+FROM ghcr.io/jbirddog/typeahead-data:main AS data
 
 FROM rust:1-slim-bullseye AS build
 


### PR DESCRIPTION
Needed one build after the repo rename where the old data images were referenced until the new data images were built. Now that that is over, reference the new images.